### PR TITLE
release twitch_oauth2 0.4.1 & release twitch_api2 0.4.0 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "twitch_api2"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "displaydoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "twitch_oauth2"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "displaydoc",

--- a/oauth2/Cargo.toml
+++ b/oauth2/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "twitch_oauth2"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Emil Gardström <emil.gardstrom@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/Emilgardis/twitch_utils"
 license = "MIT OR Apache-2.0"
 description = "Oauth2 for Twitch endpoints"
 keywords = ["oauth", "twitch","async","asynchronous"]
-documentation = "https://docs.rs/twitch_oauth2/0.4.0"
+documentation = "https://docs.rs/twitch_oauth2/0.4.1"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/oauth2/README.md
+++ b/oauth2/README.md
@@ -1,7 +1,7 @@
 Twitch OAuth2 | OAuth2 for Twitch endpoints
 ============================================
 
-[![github]](https://github.com/emilgardis/twitch_utils)&ensp;[![crates-io]](https://crates.io/crates/twitch_oauth2)&ensp;[![docs-rs]](https://docs.rs/twitch_oauth2/0.4.0/twitch_oauth2)
+[![github]](https://github.com/emilgardis/twitch_utils)&ensp;[![crates-io]](https://crates.io/crates/twitch_oauth2)&ensp;[![docs-rs]](https://docs.rs/twitch_oauth2/0.4.1/twitch_oauth2)
 
 [github]: https://img.shields.io/badge/github-emilgardis/twitch__utils-8da0cb?style=for-the-badge&labelColor=555555&logo=github"
 [crates-io]: https://img.shields.io/crates/v/twitch_oauth2.svg?style=for-the-badge&color=fc8d62&logo=rust"

--- a/oauth2/src/lib.rs
+++ b/oauth2/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unknown_lints)] // remove once broken_intra_doc_links is on stable
 #![deny(missing_docs, broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/twitch_oauth2/0.4.0")]
-//! [![github]](https://github.com/emilgardis/twitch_utils)&ensp;[![crates-io]](https://crates.io/crates/twitch_oauth2)&ensp;[![docs-rs]](https://docs.rs/twitch_oauth2/0.4.0/twitch_oauth2)
+#![doc(html_root_url = "https://docs.rs/twitch_oauth2/0.4.1")]
+//! [![github]](https://github.com/emilgardis/twitch_utils)&ensp;[![crates-io]](https://crates.io/crates/twitch_oauth2)&ensp;[![docs-rs]](https://docs.rs/twitch_oauth2/0.4.1/twitch_oauth2)
 //!
 //! [github]: https://img.shields.io/badge/github-emilgardis/twitch__utils-8da0cb?style=for-the-badge&labelColor=555555&logo=github"
 //! [crates-io]: https://img.shields.io/crates/v/twitch_oauth2.svg?style=for-the-badge&color=fc8d62&logo=rust"

--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,5 @@
 no-dev-version = true
 pre-release-commit-message = "release {{crate_name}} {{version}}"
 tag-message = "release {{crate_name}} {{tag_name}}"
+disable-publish = true
+disable-tag = true

--- a/twitchapi/Cargo.toml
+++ b/twitchapi/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "twitch_api2"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Emil Gardström <emil.gardstrom@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/Emilgardis/twitch_utils"
 license = "MIT OR Apache-2.0"
 description = "Library for talking with the new Twitch API aka. \"Helix\" and TMI."
 keywords = ["oauth", "twitch", "async", "asynchronous", "api"]
-documentation = "https://docs.rs/twitch_api2/0.3.0"
+documentation = "https://docs.rs/twitch_api2/0.4.0"
 readme = "README.md"
 build = "build.rs"
 [dependencies]

--- a/twitchapi/README.md
+++ b/twitchapi/README.md
@@ -1,7 +1,7 @@
 Twitch API2 | Rust library for talking with the new Twitch API aka. "Helix" and TMI.
 ============================================
 
-[![github]](https://github.com/emilgardis/twitch_utils)&ensp;[![crates-io]](https://crates.io/crates/twitch_api2)&ensp;[![docs-rs]](https://docs.rs/twitch_api2/0.3.0/twitch_api2)
+[![github]](https://github.com/emilgardis/twitch_utils)&ensp;[![crates-io]](https://crates.io/crates/twitch_api2)&ensp;[![docs-rs]](https://docs.rs/twitch_api2/0.4.0/twitch_api2)
 
  [github]: https://img.shields.io/badge/github-emilgardis/twitch__utils-8da0cb?style=for-the-badge&labelColor=555555&logo=github"
  [crates-io]: https://img.shields.io/crates/v/twitch_api2.svg?style=for-the-badge&color=fc8d62&logo=rust"

--- a/twitchapi/src/lib.rs
+++ b/twitchapi/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unknown_lints)] // remove once broken_intra_doc_links is on stable
 #![deny(missing_docs, broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/twitch_api2/0.3.0")]
-//! [![github]](https://github.com/emilgardis/twitch_utils)&ensp;[![crates-io]](https://crates.io/crates/twitch_api2)&ensp;[![docs-rs]](https://docs.rs/twitch_api2/0.3.0/twitch_api2)
+#![doc(html_root_url = "https://docs.rs/twitch_api2/0.4.0")]
+//! [![github]](https://github.com/emilgardis/twitch_utils)&ensp;[![crates-io]](https://crates.io/crates/twitch_api2)&ensp;[![docs-rs]](https://docs.rs/twitch_api2/0.4.0/twitch_api2)
 //!
 //! [github]: https://img.shields.io/badge/github-emilgardis/twitch__utils-8da0cb?style=for-the-badge&labelColor=555555&logo=github"
 //! [crates-io]: https://img.shields.io/crates/v/twitch_api2.svg?style=for-the-badge&color=fc8d62&logo=rust"


### PR DESCRIPTION
# twitch_oauth2 0.4.1

## Changes
- add `ChannelEditCommercial` scope.
- fix status code in, kinda...

# twitch_api2 0.4.0

## Breaking Changes

- rename `helix::channel` to `helix::channels`, and rename `GetChannel` to `GetChannelInformation`
- `RequestError::QuerySerializeError` is a custom serializers error now.

## Changes
- added `start_commercial`, `check_automod_status` and `get_broadcaster_subscriptions`
- removed dependency on `serde_urlencoded`